### PR TITLE
dkms: Add dkms support back, solved some missing definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,30 @@
 # License v2. See the file COPYING in the main directory of this archive for
 # more details.
 #
+ifneq ($(DKMS_BUILD),)
+# DKMS
+KERN_DIR := /lib/modules/$(KERNELRELEASE)/build
+
+ccflags-y := -Wno-error -isystem include/uapi/drm $(CFLAGS) $(EL8FLAG) $(EL9FLAG) $(RPIFLAG)
+evdi-lindroid-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o
+evdi-lindroid-$(CONFIG_COMPAT) += evdi_ioc32.o
+obj-m := evdi-lindroid.o
+
+KBUILD_VERBOSE ?= 1
+
+all:
+	$(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) M=$(CURDIR) SUBDIRS=$(CURDIR) SRCROOT=$(CURDIR) CONFIG_MODULE_SIG= -C $(KERN_DIR) modules
+
+clean:
+	@echo $(KERN_DIR)
+	$(MAKE) KBUILD_VERBOSE=$(KBUILD_VERBOSE) M=$(CURDIR) SUBDIRS=$(CURDIR) SRCROOT=$(CURDIR) -C $(KERN_DIR) clean
+
+else
 
 ccflags-y := -isystem include/uapi/drm $(CFLAGS) $(EL8FLAG) $(EL9FLAG) $(RPIFLAG)
 evdi-y := evdi_platform_drv.o evdi_platform_dev.o evdi_sysfs.o evdi_modeset.o evdi_connector.o evdi_encoder.o evdi_drm_drv.o evdi_fb.o evdi_gem.o evdi_painter.o evdi_params.o evdi_cursor.o evdi_debug.o
 evdi-$(CONFIG_COMPAT) += evdi_ioc32.o
 obj-$(CONFIG_DRM_LINDROID_EVDI) := evdi.o
 obj-y += tests/
+
+endif # ifneq ($(DKMS_BUILD),)

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,17 @@
+## @file
+# Linux DKMS config script for the EVDI kernel modules
+#
+
+#
+# Copyright (c) 2015 - 2020 DisplayLink (UK) Ltd.
+#
+
+PACKAGE_NAME="evdi-lindroid"
+PACKAGE_VERSION=0.0
+AUTOINSTALL=yes
+
+MAKE[0]="make all INCLUDEDIR=/lib/modules/$kernelver/build/include KVERSION=$kernelver DKMS_BUILD=1"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/gpu/drm/evdi-lindroid"
+BUILT_MODULE_NAME[0]="evdi-lindroid"
+CLEAN="make clean KERNELRELEASE=$kernelver DKMS_BUILD=1"
+

--- a/dkms.conf
+++ b/dkms.conf
@@ -5,6 +5,8 @@
 #
 # Copyright (c) 2015 - 2020 DisplayLink (UK) Ltd.
 #
+# Copyright (c) 2024 Lindroid Project.
+# 
 
 PACKAGE_NAME="evdi-lindroid"
 PACKAGE_VERSION=0.0

--- a/evdi_drm_drv.h
+++ b/evdi_drm_drv.h
@@ -150,7 +150,8 @@ struct drm_framebuffer *evdi_fb_user_fb_create(
 				struct drm_device *dev,
 				struct drm_file *file,
 				const struct drm_mode_fb_cmd2 *mode_cmd);
-
+int evdi_gem_create(struct drm_file *file,
+		struct drm_device *dev, uint64_t size, uint32_t *handle_p);
 int evdi_dumb_create(struct drm_file *file_priv,
 		     struct drm_device *dev, struct drm_mode_create_dumb *args);
 int evdi_gem_mmap(struct drm_file *file_priv,
@@ -183,6 +184,7 @@ void evdi_painter_close(struct evdi_device *evdi, struct drm_file *file);
 int evdi_painter_get_num_dirts(struct evdi_painter *painter);
 void evdi_painter_mark_dirty(struct evdi_device *evdi,
 			     const struct drm_clip_rect *rect);
+void evdi_painter_send_vblank(struct evdi_painter *painter);
 void evdi_painter_set_vblank(struct evdi_painter *painter,
 			     struct drm_crtc *crtc,
 			     struct drm_pending_vblank_event *vblank);


### PR DESCRIPTION
Brought DKMS back so it's much more convenient to build this kernel module.(Android kernel can be used with DKMS)
Function `evdi_gem_create` and `evdi_painter_send_vblank` is missing in headers. Added them to the mostly likely place for them.