### PR TITLE
evdi_drm_drv: make it compatible with gnu89

### DIFF
--- a/evdi_drm_drv.c
+++ b/evdi_drm_drv.c
@@ -539,6 +539,7 @@ int evdi_poll_ioctl(struct drm_device *drm_dev, void *data,
 
 	switch(cmd->event) {
 		case add_buf:
+			{
 			struct evdi_gralloc_buf *add_gralloc_buf = event->data;
 			fd = get_unused_fd_flags(O_RDWR);
 			if (fd < 0) {
@@ -566,6 +567,7 @@ int evdi_poll_ioctl(struct drm_device *drm_dev, void *data,
 				return -EFAULT;
 			}
 			break;
+			}
 		case get_buf:
 		case swap_to:
 		case destroy_buf:


### PR DESCRIPTION
Without this pair of '{}', gcc will complain `expect expression` after line 541 when using gnu89 standard. Some kernels use this standard and it's not wise to change it... 
Adding it seems solved this, the module compiled and loaded successfully, but Idk if there're any side effects(I cannot test it because Idk how).