### PR TITLE
Remove "depends on DRM"

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -8,7 +8,6 @@
 
 config DRM_LINDROID_EVDI
 	tristate "Extensible Virtual Display Interface"
-	depends on DRM
 	depends on MODULES
 	select DRM_KMS_HELPER
 	help


### PR DESCRIPTION
If CONFIG_DRM=y is not present in defconfig and depends on DRM is here the module is not getting compiled. According to discussions CONFIG_DRM is not needed https://t.me/linux_on_droid/21605