### PR TITLE
More improvements:

### DIFF
--- a/evdi_drm_drv.c
+++ b/evdi_drm_drv.c
@@ -19,6 +19,7 @@
 #include <linux/version.h>
 #include <linux/sched/signal.h>
 #include <linux/wait.h>
+#include <linux/slab.h>
 #if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 #include <drm/drm_ioctl.h>
 #include <drm/drm_file.h>
@@ -79,6 +80,9 @@ int evdi_gbm_create_buff(struct drm_device *dev, void *data,
 
 int evdi_create_buff_callback_ioctl(struct drm_device *drm_dev, void *data,
                     struct drm_file *file);
+
+static struct kmem_cache *evdi_event_cache;
+static atomic_t evdi_event_cache_users = ATOMIC_INIT(0);
 
 struct drm_ioctl_desc evdi_painter_ioctls[] = {
 	DRM_IOCTL_DEF_DRV(EVDI_CONNECT, evdi_painter_connect_ioctl, EVDI_DRM_UNLOCKED),
@@ -254,7 +258,9 @@ static struct drm_driver driver = {
 
 struct evdi_event *evdi_create_event(struct evdi_device *evdi, enum poll_event_type type, void *data)
 {
-	struct evdi_event *event = kzalloc(sizeof(*event), GFP_KERNEL);
+	struct evdi_event *event;
+
+	event = kmem_cache_zalloc(evdi_event_cache, GFP_KERNEL);
 	if (!event)
 		return NULL;
 
@@ -264,28 +270,49 @@ struct evdi_event *evdi_create_event(struct evdi_device *evdi, enum poll_event_t
 	event->completed = false;
 	event->evdi = evdi;
 
-	mutex_lock(&evdi->event_lock);
-
-	event->poll_id = atomic_fetch_inc(&evdi->next_event_id);
 	idr_preload(GFP_KERNEL);
-	{
-		int ret = idr_alloc(&evdi->event_idr, event,
-				    event->poll_id, event->poll_id + 1, GFP_NOWAIT);
-		if (ret < 0) {
-			idr_preload_end();
-			mutex_unlock(&evdi->event_lock);
-			kfree(event);
-			return NULL;
-		}
+	mutex_lock(&evdi->event_lock);
+	event->poll_id = atomic_fetch_inc(&evdi->next_event_id);
+	if (idr_alloc(&evdi->event_idr, event,
+		      event->poll_id, event->poll_id + 1, GFP_NOWAIT) < 0) {
+		mutex_unlock(&evdi->event_lock);
+		idr_preload_end();
+		kmem_cache_free(evdi_event_cache, event);
+		return NULL;
 	}
+	list_add_tail(&event->list, &evdi->event_queue);
+	mutex_unlock(&evdi->event_lock);
 	idr_preload_end();
 
-	list_add_tail(&event->list, &evdi->event_queue);
-
-	mutex_unlock(&evdi->event_lock);
 	return event;
 }
 
+void evdi_event_free(struct evdi_event *event)
+{
+	if (event)
+		kmem_cache_free(evdi_event_cache, event);
+}
+
+static int evdi_event_cache_get(void)
+{
+	if (!evdi_event_cache) {
+		evdi_event_cache = kmem_cache_create("evdi_event",
+						     sizeof(struct evdi_event),
+						     0, SLAB_HWCACHE_ALIGN, NULL);
+		if (!evdi_event_cache)
+			return -ENOMEM;
+	}
+	atomic_inc(&evdi_event_cache_users);
+	return 0;
+}
+
+static void evdi_event_cache_put(void)
+{
+	if (atomic_dec_and_test(&evdi_event_cache_users) && evdi_event_cache) {
+		kmem_cache_destroy(evdi_event_cache);
+		evdi_event_cache = NULL;
+	}
+}
 
 int evdi_swap_callback_ioctl(struct drm_device *drm_dev, void *data,
                     struct drm_file *file)
@@ -619,7 +646,7 @@ int evdi_gbm_add_buf_ioctl(struct drm_device *dev, void *data,
 	mutex_lock(&evdi->event_lock);
 	idr_remove(&evdi->event_idr, event->poll_id);
 	mutex_unlock(&evdi->event_lock);
-	kfree(event);
+	evdi_event_free(event);
 	EVDI_SAFE_KFREE(installed_fd_tmps);
 	return 0;
 
@@ -631,7 +658,7 @@ int evdi_gbm_add_buf_ioctl(struct drm_device *dev, void *data,
 	mutex_lock(&evdi->event_lock);
 	idr_remove(&evdi->event_idr, event->poll_id);
 	mutex_unlock(&evdi->event_lock);
-	kfree(event);
+	evdi_event_free(event);
 	EVDI_SAFE_KFREE(installed_fd_tmps);
 	return ret ? ret : -ETIMEDOUT;
 }
@@ -718,7 +745,7 @@ int evdi_gbm_get_buf_ioctl(struct drm_device *dev, void *data,
 	mutex_lock(&evdi->event_lock);
 	idr_remove(&evdi->event_idr, event->poll_id);
 	mutex_unlock(&evdi->event_lock);
-	kfree(event);
+	evdi_event_free(event);
 	EVDI_SAFE_KFREE(installed_fds);
 
 	return 0;
@@ -738,7 +765,7 @@ err_event:
 	mutex_lock(&evdi->event_lock);
 	idr_remove(&evdi->event_idr, event->poll_id);
 	mutex_unlock(&evdi->event_lock);
-	kfree(event);
+	evdi_event_free(event);
 	EVDI_SAFE_KFREE(installed_fds);
 	return ret ? ret : -ETIMEDOUT;
 }
@@ -775,7 +802,7 @@ int evdi_gbm_del_buf_ioctl(struct drm_device *dev, void *data,
 	mutex_lock(&evdi->event_lock);
 	idr_remove(&evdi->event_idr, event->poll_id);
 	mutex_unlock(&evdi->event_lock);
-	kfree(event);
+	evdi_event_free(event);
 
 	return ret > 0 ? 0 : ret;
 }
@@ -818,7 +845,7 @@ int evdi_gbm_create_buff (struct drm_device *dev, void *data,
 	idr_remove(&evdi->event_idr, event->poll_id);
 	mutex_unlock(&evdi->event_lock);
 	kfree(cb_cmd);
-	kfree(event);
+	evdi_event_free(event);
 
 	return 0;
 
@@ -828,7 +855,7 @@ err_event:
 	mutex_unlock(&evdi->event_lock);
 	if (event->reply_data)
 		kfree(event->reply_data);
-	kfree(event);
+	evdi_event_free(event);
 	return ret ? ret : -ETIMEDOUT;
 }
 
@@ -979,6 +1006,7 @@ static void evdi_drm_device_release_cb(__always_unused struct drm_device *dev,
 	kfree(evdi);
 	dev->dev_private = NULL;
 	EVDI_INFO("Evdi drm_device removed.\n");
+	evdi_event_cache_put();
 
 	EVDI_TEST_HOOK(evdi_testhook_drm_device_destroyed());
 }
@@ -1004,6 +1032,10 @@ static int evdi_drm_device_init(struct drm_device *dev)
 	mutex_init(&evdi->poll_lock);
 	init_completion(&evdi->poll_completion);
 	evdi->poll_data_size = -1;
+
+	ret = evdi_event_cache_get();
+	if (ret)
+		goto err_free;
 
 	mutex_init(&evdi->event_lock);
 	INIT_LIST_HEAD(&evdi->event_queue);

--- a/evdi_drm_drv.c
+++ b/evdi_drm_drv.c
@@ -477,14 +477,18 @@ int evdi_create_buff_callback_ioctl(struct drm_device *drm_dev, void *data,
 	struct evdi_device *evdi = drm_dev->dev_private;
 	struct drm_evdi_create_buff_callabck *cmd = data;
 	struct evdi_event *event;
-	struct drm_evdi_create_buff_callabck *buf = kzalloc(sizeof(struct drm_evdi_create_buff_callabck), GFP_KERNEL);
-	memcpy(buf, data, sizeof(struct drm_evdi_create_buff_callabck));
+	struct drm_evdi_create_buff_callabck *buf = kmemdup(data, sizeof(*buf), GFP_KERNEL);
+	if (!buf)
+		return -ENOMEM;
+
 	mutex_lock(&evdi->event_lock);
 	event = idr_find(&evdi->event_idr, cmd->poll_id);
 	mutex_unlock(&evdi->event_lock);
 
-	if (!event)
+	if (!event) {
+		kfree(buf);
 		return -EINVAL;
+	}
 
 	event->result = 0;
 	event->completed = true;

--- a/evdi_drm_drv.c
+++ b/evdi_drm_drv.c
@@ -512,6 +512,12 @@ int evdi_gbm_add_buf_ioctl(struct drm_device *dev, void *data,
 	loff_t pos;
 	int i;
 	int *installed_fd_tmps = NULL;
+	int *fd_array = NULL;
+	struct {
+		int version;
+		int numFds;
+		int numInts;
+	} hdr;
 
 	memfd_file = fget(cmd->fd);
 	if (!memfd_file) {
@@ -520,26 +526,17 @@ int evdi_gbm_add_buf_ioctl(struct drm_device *dev, void *data,
 	}
 
 	pos = 0; /* Initialize offset */
-	bytes_read = kernel_read(memfd_file, &version, sizeof(version), &pos);
-	if (bytes_read != sizeof(version)) {
-		EVDI_ERROR("Failed to read version from memfd, bytes_read=%zd\n", bytes_read);
+	bytes_read = kernel_read(memfd_file, &hdr, sizeof(hdr), &pos);
+	if (bytes_read != sizeof(hdr)) {
+		EVDI_ERROR("Failed to read header from memfd, bytes_read=%zd\n", bytes_read);
 		fput(memfd_file);
 		return -EIO;
 	}
 
-	bytes_read = kernel_read(memfd_file, &numFds, sizeof(numFds), &pos);
-	if (bytes_read != sizeof(numFds)) {
-		EVDI_ERROR("Failed to read numFds from memfd, bytes_read=%zd\n", bytes_read);
-		fput(memfd_file);
-		return -EIO;
-	}
+	version = hdr.version;
+	numFds = hdr.numFds;
+	numInts = hdr.numInts;
 
-	bytes_read = kernel_read(memfd_file, &numInts, sizeof(numInts), &pos);
-	if (bytes_read != sizeof(numInts)) {
-		EVDI_ERROR("Failed to read numInts from memfd, bytes_read=%zd\n", bytes_read);
-		fput(memfd_file);
-		return -EIO;
-	}
 	add_gralloc_buf = kzalloc(sizeof(struct evdi_gralloc_buf), GFP_KERNEL);
 	if (!add_gralloc_buf) {
 		fput(memfd_file);
@@ -569,11 +566,20 @@ int evdi_gbm_add_buf_ioctl(struct drm_device *dev, void *data,
 		return -ENOMEM;
 	}
 
-	for (i = 0; i < numFds; i++) {
-		installed_fd_tmps[i] = -1;
-		bytes_read = kernel_read(memfd_file, &fd, sizeof(fd), &pos);
-		if (bytes_read != sizeof(fd)) {
-			EVDI_ERROR("Failed to read fd from memfd, bytes_read=%zd\n", bytes_read);
+	if (numFds) {
+		fd_array = kcalloc(numFds, sizeof(int), GFP_KERNEL);
+		if (!fd_array) {
+			EVDI_SAFE_KFREE(add_gralloc_buf->data_ints);
+			EVDI_SAFE_KFREE(add_gralloc_buf->data_files);
+			kfree(add_gralloc_buf);
+			fput(memfd_file);
+			EVDI_SAFE_KFREE(installed_fd_tmps);
+			return -ENOMEM;
+		}
+		bytes_read = kernel_read(memfd_file, fd_array, sizeof(int) * numFds, &pos);
+		if (bytes_read != sizeof(int) * numFds) {
+			EVDI_ERROR("Failed to read fd array from memfd, bytes_read=%zd\n", bytes_read);
+			EVDI_SAFE_KFREE(fd_array);
 			EVDI_SAFE_KFREE(add_gralloc_buf->data_ints);
 			EVDI_SAFE_KFREE(add_gralloc_buf->data_files);
 			kfree(add_gralloc_buf);
@@ -581,18 +587,23 @@ int evdi_gbm_add_buf_ioctl(struct drm_device *dev, void *data,
 			EVDI_SAFE_KFREE(installed_fd_tmps);
 			return -EIO;
 		}
-		fd_file = fget(fd);
-		if (!fd_file) {
-			EVDI_ERROR("Failed to open fake fb's %d fd file: %d\n", cmd->fd, fd);
-			EVDI_SAFE_KFREE(add_gralloc_buf->data_ints);
-			EVDI_SAFE_KFREE(add_gralloc_buf->data_files);
-			kfree(add_gralloc_buf);
-			fput(memfd_file);
-			EVDI_SAFE_KFREE(installed_fd_tmps);
-			return -EINVAL;
+		for (i = 0; i < numFds; i++) {
+			installed_fd_tmps[i] = -1;
+			fd = fd_array[i];
+			fd_file = fget(fd);
+			if (!fd_file) {
+				EVDI_ERROR("Failed to open fake fb's %d fd file: %d\n", cmd->fd, fd);
+				EVDI_SAFE_KFREE(fd_array);
+				EVDI_SAFE_KFREE(add_gralloc_buf->data_ints);
+				EVDI_SAFE_KFREE(add_gralloc_buf->data_files);
+				kfree(add_gralloc_buf);
+				fput(memfd_file);
+				EVDI_SAFE_KFREE(installed_fd_tmps);
+				return -EINVAL;
+			}
+			add_gralloc_buf->data_files[i] = fd_file;
 		}
-		add_gralloc_buf->data_files[i] = fd_file;
-
+		EVDI_SAFE_KFREE(fd_array);
 	}
 
 	bytes_read = kernel_read(memfd_file, add_gralloc_buf->data_ints, sizeof(int) *numInts, &pos);
@@ -937,23 +948,24 @@ int evdi_poll_ioctl(struct drm_device *drm_dev, void *data,
 				reserved_fd_tmps[i] = fd_tmp;
 			}
 
-			for (i = 0; i < add_gralloc_buf->numFds; i++) {
+			for (i = 0; i < add_gralloc_buf->numFds; i++)
 				fput(add_gralloc_buf->data_files[i]);
-				pos = sizeof(int) * (3 + i);
-				bytes_write = kernel_write(add_gralloc_buf->memfd_file,
-							   &reserved_fd_tmps[i], sizeof(reserved_fd_tmps[i]), &pos);
-				if (bytes_write != sizeof(fd_tmp)) {
-					EVDI_ERROR("Failed to write fd\n");
-					for (; i >= 0; i--)
-						put_unused_fd(reserved_fd_tmps[i]);
 
-					put_unused_fd(fd);
-					EVDI_SAFE_KFREE(reserved_fd_tmps);
-					EVDI_SAFE_KFREE(add_gralloc_buf->data_ints);
-					EVDI_SAFE_KFREE(add_gralloc_buf->data_files);
-					kfree(add_gralloc_buf);
-					return -EFAULT;
-				}
+			pos = sizeof(int) * 3;
+			bytes_write = kernel_write(add_gralloc_buf->memfd_file,
+						   reserved_fd_tmps,
+						   sizeof(int) * add_gralloc_buf->numFds,
+						   &pos);
+			if (bytes_write != sizeof(int) * add_gralloc_buf->numFds) {
+				EVDI_ERROR("Failed to write fd array\n");
+				for (i = 0; i < add_gralloc_buf->numFds; i++)
+					put_unused_fd(reserved_fd_tmps[i]);
+				put_unused_fd(fd);
+				EVDI_SAFE_KFREE(reserved_fd_tmps);
+				EVDI_SAFE_KFREE(add_gralloc_buf->data_ints);
+				EVDI_SAFE_KFREE(add_gralloc_buf->data_files);
+				kfree(add_gralloc_buf);
+				return -EFAULT;
 			}
 
 			if (evdi_copy_to_user_allow_partial((void __user *)cmd->data, &fd, sizeof(fd))) {

--- a/evdi_drm_drv.h
+++ b/evdi_drm_drv.h
@@ -18,6 +18,7 @@
 #include <linux/mutex.h>
 #include <linux/device.h>
 #include <linux/atomic.h>
+#include <linux/completion.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0) || defined(EL8) || defined(EL9)
 #include <linux/xarray.h>
 #define EVDI_HAVE_XARRAY	1
@@ -46,6 +47,8 @@
 #include "evdi_debug.h"
 #include "evdi_drm.h"
 #include "tests/evdi_test.h"
+
+#define EVDI_WAIT_TIMEOUT (5*HZ)
 
 struct evdi_fbdev;
 struct evdi_painter;
@@ -88,8 +91,7 @@ struct evdi_event {
 	void *data;
 	void *reply_data;
 	int poll_id;
-	wait_queue_head_t wait;
-	bool completed;
+	struct completion done;
 	int result;
 
 	struct list_head list;

--- a/evdi_drm_drv.h
+++ b/evdi_drm_drv.h
@@ -17,6 +17,7 @@
 #include <linux/version.h>
 #include <linux/mutex.h>
 #include <linux/device.h>
+#include <linux/atomic.h>
 #if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 #include <drm/drm_drv.h>
 #include <drm/drm_fourcc.h>
@@ -62,6 +63,7 @@ struct evdi_device {
 	wait_queue_head_t poll_ioct_wq;
 	wait_queue_head_t poll_response_ioct_wq;
 	struct mutex poll_lock;
+	atomic_t poll_stopping;
 	struct completion poll_completion;
 	int last_buf_add_id;
 	void *last_got_buff;

--- a/evdi_drm_drv.h
+++ b/evdi_drm_drv.h
@@ -67,7 +67,7 @@ struct evdi_device {
 	struct completion poll_completion;
 	int last_buf_add_id;
 	void *last_got_buff;
-	struct mutex event_lock;
+	spinlock_t event_lock;
 	struct list_head event_queue;
 	struct idr event_idr;
 	atomic_t next_event_id;

--- a/evdi_drm_drv.h
+++ b/evdi_drm_drv.h
@@ -257,4 +257,5 @@ void evdi_painter_force_full_modeset(struct evdi_painter *painter);
 struct drm_clip_rect evdi_painter_framebuffer_size(struct evdi_painter *painter);
 
 int evdi_fb_get_bpp(uint32_t format);
+void evdi_event_free(struct evdi_event *e);
 #endif

--- a/evdi_drm_drv.h
+++ b/evdi_drm_drv.h
@@ -18,6 +18,12 @@
 #include <linux/mutex.h>
 #include <linux/device.h>
 #include <linux/atomic.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0) || defined(EL8) || defined(EL9)
+#include <linux/xarray.h>
+#define EVDI_HAVE_XARRAY	1
+#else
+#undef EVDI_HAVE_XARRAY
+#endif
 #if KERNEL_VERSION(5, 5, 0) <= LINUX_VERSION_CODE || defined(EL8) || defined(EL9)
 #include <drm/drm_drv.h>
 #include <drm/drm_fourcc.h>
@@ -69,7 +75,11 @@ struct evdi_device {
 	void *last_got_buff;
 	spinlock_t event_lock;
 	struct list_head event_queue;
+#if defined(EVDI_HAVE_XARRAY)
+	struct xarray event_xa;
+#else
 	struct idr event_idr;
+#endif
 	atomic_t next_event_id;
 };
 

--- a/evdi_fb.c
+++ b/evdi_fb.c
@@ -218,7 +218,11 @@ static void evdi_user_framebuffer_destroy(struct drm_framebuffer *fb)
 	}
 
 	spin_lock(&evdi->event_lock);
+#if defined(EVDI_HAVE_XARRAY)
+	xa_erase(&evdi->event_xa, event->poll_id);
+#else
 	idr_remove(&evdi->event_idr, event->poll_id);
+#endif
 	spin_unlock(&evdi->event_lock);
 	evdi_event_free(event);
 

--- a/evdi_fb.c
+++ b/evdi_fb.c
@@ -205,7 +205,7 @@ static void evdi_user_framebuffer_destroy(struct drm_framebuffer *fb)
 		return;
 
 	wake_up(&evdi->poll_ioct_wq);
-	ret = wait_event_interruptible(event->wait, event->completed);
+	ret = wait_for_completion_interruptible_timeout(&event->done, EVDI_WAIT_TIMEOUT);
 	if (ret < 0) {
 		EVDI_ERROR("evdi_gbm_add_buf_ioctl: wait_event_interruptible interrupted: %d\n", ret);
 		return;

--- a/evdi_fb.c
+++ b/evdi_fb.c
@@ -217,9 +217,9 @@ static void evdi_user_framebuffer_destroy(struct drm_framebuffer *fb)
 		return;
 	}
 
-	mutex_lock(&evdi->event_lock);
+	spin_lock(&evdi->event_lock);
 	idr_remove(&evdi->event_idr, event->poll_id);
-	mutex_unlock(&evdi->event_lock);
+	spin_unlock(&evdi->event_lock);
 	evdi_event_free(event);
 
 	kfree(efb);

--- a/evdi_fb.c
+++ b/evdi_fb.c
@@ -220,7 +220,7 @@ static void evdi_user_framebuffer_destroy(struct drm_framebuffer *fb)
 	mutex_lock(&evdi->event_lock);
 	idr_remove(&evdi->event_idr, event->poll_id);
 	mutex_unlock(&evdi->event_lock);
-	kfree(event);
+	evdi_event_free(event);
 
 	kfree(efb);
 }

--- a/evdi_modeset.c
+++ b/evdi_modeset.c
@@ -241,7 +241,7 @@ int evdi_atomic_helper_page_flip(struct drm_crtc *crtc,
 		return -ENOMEM;
 
 	wake_up(&evdi->poll_ioct_wq);
-	ret = wait_event_interruptible(ev_event->wait, ev_event->completed);
+	ret = wait_for_completion_interruptible_timeout(&ev_event->done, EVDI_WAIT_TIMEOUT);
 	if (ret < 0) {
 		EVDI_INFO("evdi_gbm_add_buf_ioctl: wait_event_interruptible interrupted: %d\n", ret);
 		return ret;

--- a/evdi_modeset.c
+++ b/evdi_modeset.c
@@ -254,7 +254,11 @@ int evdi_atomic_helper_page_flip(struct drm_crtc *crtc,
 	}
 
 	spin_lock(&evdi->event_lock);
+#if defined(EVDI_HAVE_XARRAY)
+	xa_erase(&evdi->event_xa, ev_event->poll_id);
+#else
 	idr_remove(&evdi->event_idr, ev_event->poll_id);
+#endif
 	spin_unlock(&evdi->event_lock);
 	evdi_event_free(ev_event);
 

--- a/evdi_modeset.c
+++ b/evdi_modeset.c
@@ -253,9 +253,9 @@ int evdi_atomic_helper_page_flip(struct drm_crtc *crtc,
 		return ret;
 	}
 
-	mutex_lock(&evdi->event_lock);
+	spin_lock(&evdi->event_lock);
 	idr_remove(&evdi->event_idr, ev_event->poll_id);
-	mutex_unlock(&evdi->event_lock);
+	spin_unlock(&evdi->event_lock);
 	evdi_event_free(ev_event);
 
 	evdi_painter_send_vblank(evdi->painter);

--- a/evdi_modeset.c
+++ b/evdi_modeset.c
@@ -256,7 +256,7 @@ int evdi_atomic_helper_page_flip(struct drm_crtc *crtc,
 	mutex_lock(&evdi->event_lock);
 	idr_remove(&evdi->event_idr, ev_event->poll_id);
 	mutex_unlock(&evdi->event_lock);
-	kfree(ev_event);
+	evdi_event_free(ev_event);
 
 	evdi_painter_send_vblank(evdi->painter);
 


### PR DESCRIPTION
 - lindroid-drm-loopback: make poll ioctl interruptible, wake on disconnect 
 - lindroid-drm-loopback: evdi_painter: improve dirty rect handling
 - lindroid-drm-loopback: evdi events: minimize locking, utilize kmem_cache
 - lindroid-drm-loopback: evdi_painter: move all events to kmem caches
 - lindroid-drm-loopback: evdi_create_buff_callback_ioctl kzalloc->kmemdup
 - lindroid-drm-loopback: move evdi->event_lock to spinlock
 - lindroid-drm-loopback: back memfds
 - lindroid-drm-loopback: utilize XArray over IDR if supported
 - lindroid-drm-loopback: move to completion for polling

Tested on 6.1.